### PR TITLE
Add a scale of spacing variables which can be used for spacing

### DIFF
--- a/_assets/main.css
+++ b/_assets/main.css
@@ -1,3 +1,16 @@
+:root {
+  --spacer-xxs: 0.25rem;
+  --spacer-xs: 0.5rem;
+  --spacer-sm: 0.75rem;
+  --spacer-md: 1.25rem;
+  --spacer-lg: 2rem;
+  --spacer-xl: 3.25rem;
+}
+
+body {
+  padding: var(--spacer-md);
+}
+
 div.footnotes {
   font-size: .8em;
 }
@@ -23,7 +36,7 @@ a {
 
 nav ul {
   display: inline;
-  padding-left: 1em;
+  padding-left: var(--spacer-md);
 }
 
 @media (max-width: 768px) {
@@ -35,7 +48,7 @@ nav ul {
 
 nav li {
   display: inline;
-  padding-right: .5em;
+  padding-right: var(--spacer-sm);
 }
 
 nav li::before {
@@ -53,13 +66,13 @@ nav li.active::before {
 .masonry {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
-  gap: 1rem;
+  gap: var(--spacer-lg);
 }
 
 .gallery {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
-  gap: 1rem;
+  gap: var(--spacer-md);
 }
 
 @media (max-width: 768px) {
@@ -73,8 +86,8 @@ nav li.active::before {
   .figure-float-right {
     float: right !important;
     max-width: 40%;
-    margin-bottom: 1rem;
-    margin-left: 1rem;
+    margin-bottom: var(--spacer-sm);
+    margin-left: var(--spacer-lg);
   }
 }
 
@@ -312,4 +325,28 @@ blockquote > p {
 .copyright-notice {
   font-size: .8em;
   color: var(--text-muted);
+}
+
+.mt-xxs {
+  margin-top: var(--spacer-xxs);
+}
+
+.mt-xs {
+  margin-top: var(--spacer-xs);
+}
+
+.mt-sm {
+  margin-top: var(--spacer-sm);
+}
+
+.mt-md {
+  margin-top: var(--spacer-md);
+}
+
+.mt-lg {
+  margin-top: var(--spacer-lg);
+}
+
+.mt-xl {
+  margin-top: var(--spacer-xl);
 }

--- a/_assets/main.css
+++ b/_assets/main.css
@@ -49,6 +49,7 @@ nav ul {
 nav li {
   display: inline;
   padding-right: var(--spacer-sm);
+  white-space: nowrap;
 }
 
 nav li::before {
@@ -106,9 +107,14 @@ article footer {
   margin: 0;
 }
 
+dl dd {
+  margin-top: var(--spacer-xs);
+  margin-bottom: var(--spacer-sm);
+}
+
 ul.links {
   padding-left: 0;
-  padding-bottom: 1em;
+  padding-bottom: var(--spacer-sm);
 }
 
 ul.links li {
@@ -239,8 +245,12 @@ td, th {
 }
 
 .interactive-buttons {
-  padding-top: .5em;
-  padding-bottom: .5em;
+  padding-top: var(--spacer-sm);
+  padding-bottom: var(--spacer-sm);
+}
+
+.interactive-buttons button {
+  margin-right: var(--spacer-sm);
 }
 
 .interactive .error::before {

--- a/_includes/cookies.html
+++ b/_includes/cookies.html
@@ -12,4 +12,4 @@ Feel free to use it however you like.
 <br>
 For your convenience, you can even click this button to copy a cookie to your clipboard:
 <br>
-<button onclick="copyCookie();">Copy 🍪 to clipboard</button>
+<button class="mt-sm" onclick="copyCookie();">Copy 🍪 to clipboard</button>


### PR DESCRIPTION
This is just a suggestion and can be tweaked for personal
preference. One trick to achieving consistent visual spacing is
to use a spacing scale instead of just choosing random values.
My personal preference is to use Fibonacci numbers for the scale,
so this adds some custom CSS properties which map to Fibonacci
values. These values can then be used within the CSS code.

When these values are used in the entirety of the webpage (including
the margins for headings, paragraphs, etc.), then it really helps
to achieve visual harmony. That would be a bit too large of a
change for a single commit, so this only tweaks a few CSS rules to
use the new spacing scale

This also adds a few utility classes for adding a `margin-top` to
certain elements. This change is _very_ controversial, because many
developers do not like utility classes. However, I've recently
begun to question that opinion. In my opinion, the spacing should
be a first class citizen of the CSS container components into
which we place our components. However, there are a lot of instances
where we need something like "Glue Code" to bring different
components together within a UI and give them the correct amount
of spacing. I think that utility classes are a good use case for
this particular problem -- like for the `Copy 🍪 to clipboard`
button: in this instance the button needs a bit of a margin-top,
but if we were to write a whole new class for this specific
instance of the button within the UI, it would be extremely hard
to reuse it. With utility classes, it's easier to achieve a
_certain_ amount of reusability.

Note: This method of defining spacing has a downside of not working
in super old browsers (e.g. IE11) because they do not support CSS
properties. That is a tradeoff that I personally make for my own
personal site, but if that is problematic for you, then you could
also decide not to use CSS properties but just use the scale values
directly in the CSS code (e.g. `margin-bottom: 1.25rem` instead of
`margin-bottom: var(--spacer-md);`).